### PR TITLE
Bump required poetry version to the latest, rollback exitcode crutch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,5 +35,5 @@ known_third_party = []
 
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.3.2"]
 build-backend = "poetry.core.masonry.api"

--- a/src/wafp/__main__.py
+++ b/src/wafp/__main__.py
@@ -88,10 +88,7 @@ def main(
             )
             result.cleanup()
     store_metadata(output_dir, cli_args.fuzzer, cli_args.target, target.run_id, result.duration)
-    # workaround for poetry issue, in order to make wafp more friendly to CI-systems
-    # see https://github.com/python-poetry/poetry/issues/2369
-    # TODO: rollback this when 1.2.0 will be released.
-    sys.exit(result.completed_process.returncode)
+    return result.completed_process.returncode
 
 
 def store_metadata(output_dir: pathlib.Path, fuzzer: str, target: str, run_id: str, duration: float) -> None:


### PR DESCRIPTION
Minor thing, just a rollback workaround which I put for the return codes.